### PR TITLE
Save dark mode or light mode across all pages on the website

### DIFF
--- a/retro.js
+++ b/retro.js
@@ -1,20 +1,37 @@
-// Check if user prefers dark theme
 const prefersDarkTheme = window.matchMedia("(prefers-color-scheme: dark)");
 
-// Function to toggle dark theme
-function toggleDarkTheme() {
+if (localStorage.getItem('prefersDarkTheme') === 'true' || (localStorage.getItem('prefersDarkTheme') === null && prefersDarkTheme.matches)) {
+    document.body.classList.add("dark");
+    localStorage.setItem('prefersDarkTheme', 'true');
+}
+
+if (localStorage.getItem('prefersRetro') === null) {
+    localStorage.setItem('prefersRetro', 'true');
+}
+
+if (localStorage.getItem('prefersRetro') === 'true') {
+    document.body.classList.add('retro');
+} else {
+    document.body.classList.remove('retro');
+}
+
+if (localStorage.getItem('prefersDarkTheme') === 'true') {
+    document.body.classList.add("dark");
+} else {
+    document.body.classList.remove("dark");
+}
+
+document.getElementById("retro").addEventListener("click", () => {
+    document.body.classList.toggle("retro");
+    localStorage.setItem('prefersRetro', document.body.classList.contains("retro") ? "true" : "false");
+});
+
+document.getElementById("dark").addEventListener("click", () => {
     document.body.classList.toggle("dark");
     localStorage.setItem('prefersDarkTheme', document.body.classList.contains("dark") ? "true" : "false");
     updateModeButtonText();
-}
+});
 
-// Function to toggle retro mode
-function toggleRetroMode() {
-    document.body.classList.toggle("retro");
-    localStorage.setItem('prefersRetro', document.body.classList.contains("retro") ? "true" : "false");
-}
-
-// Function to update mode button text
 function updateModeButtonText() {
     const darkModeButton = document.getElementById('dark');
     if (document.body.classList.contains("dark")) {
@@ -24,16 +41,5 @@ function updateModeButtonText() {
     }
 }
 
-// Apply saved preferences on page load
-window.addEventListener("load", () => {
-    if (localStorage.getItem('prefersDarkTheme') === 'true' || (localStorage.getItem('prefersDarkTheme') === null && prefersDarkTheme.matches)) {
-        document.body.classList.add("dark");
-    }
-    if (localStorage.getItem('prefersRetro') === 'true') {
-        document.body.classList.add('retro');
-    }
-    updateModeButtonText(); // Update mode button text on page load
-});
-
-// Event listener for the Dark Mode button
-document.getElementById("dark").addEventListener("click", toggleDarkTheme);
+// Update mode button text on page load
+updateModeButtonText();

--- a/retro.js
+++ b/retro.js
@@ -4,14 +4,14 @@ const prefersDarkTheme = window.matchMedia("(prefers-color-scheme: dark)");
 // Function to toggle dark theme
 function toggleDarkTheme() {
     document.body.classList.toggle("dark");
-    localStorage.setItem('prefersDarkTheme', document.body.classList.contains("dark"));
+    localStorage.setItem('prefersDarkTheme', document.body.classList.contains("dark") ? "true" : "false");
     updateModeButtonText();
 }
 
 // Function to toggle retro mode
 function toggleRetroMode() {
     document.body.classList.toggle("retro");
-    localStorage.setItem('prefersRetro', document.body.classList.contains("retro"));
+    localStorage.setItem('prefersRetro', document.body.classList.contains("retro") ? "true" : "false");
 }
 
 // Function to update mode button text
@@ -34,3 +34,6 @@ window.addEventListener("load", () => {
     }
     updateModeButtonText(); // Update mode button text on page load
 });
+
+// Event listener for the Dark Mode button
+document.getElementById("dark").addEventListener("click", toggleDarkTheme);

--- a/retro.js
+++ b/retro.js
@@ -1,39 +1,28 @@
+// Check if user prefers dark theme
 const prefersDarkTheme = window.matchMedia("(prefers-color-scheme: dark)");
-if (prefersDarkTheme.matches) {
-    document.body.classList.add("dark");
-    localStorage.setItem('prefersDarkTheme', 'true');
-}
 
-if (localStorage.getItem('prefersRetro') === null) {
-    localStorage.setItem('prefersRetro', 'true');
-}
-
-if (localStorage.getItem('prefersRetro') === 'true') {
-    document.body.classList.add('retro');
-} else {
-    document.body.classList.remove('retro');
-}
-
-if (localStorage.getItem('prefersDarkTheme') === 'true') {
-    document.body.classList.add("dark");
-} else {
-    document.body.classList.remove("dark");
-}
-
-document.getElementById("retro").addEventListener("click", () => {
-    document.body.classList.toggle("retro");
-    if (localStorage.getItem('prefersRetro') === 'true') {
-        localStorage.setItem('prefersRetro', 'false');
-    } else {
-        localStorage.setItem('prefersRetro', 'true');
-    }
-});
-
-document.getElementById("dark").addEventListener("click", () => {
+// Function to toggle dark theme
+function toggleDarkTheme() {
     document.body.classList.toggle("dark");
-    if (localStorage.getItem('prefersDarkTheme') === 'true') {
-        localStorage.setItem('prefersDarkTheme', 'false');
-    } else {
-        localStorage.setItem('prefersDarkTheme', 'true');
+    localStorage.setItem('prefersDarkTheme', document.body.classList.contains("dark"));
+}
+
+// Function to toggle retro mode
+function toggleRetroMode() {
+    document.body.classList.toggle("retro");
+    localStorage.setItem('prefersRetro', document.body.classList.contains("retro"));
+}
+
+// Apply saved preferences on page load
+window.addEventListener("load", () => {
+    if (localStorage.getItem('prefersDarkTheme') === 'true' || (localStorage.getItem('prefersDarkTheme') === null && prefersDarkTheme.matches)) {
+        document.body.classList.add("dark");
+    }
+    if (localStorage.getItem('prefersRetro') === 'true') {
+        document.body.classList.add('retro');
     }
 });
+
+// Event listeners for theme and retro mode buttons
+document.getElementById("retro").addEventListener("click", toggleRetroMode);
+document.getElementById("dark").addEventListener("click", toggleDarkTheme);

--- a/retro.js
+++ b/retro.js
@@ -1,19 +1,25 @@
-// Check if user prefers dark theme
 const prefersDarkTheme = window.matchMedia("(prefers-color-scheme: dark)");
 
-// Function to toggle dark theme
+function updateDarkModeButtonText() {
+    const darkButton = document.getElementById("dark");
+    if (document.body.classList.contains("dark")) {
+        darkButton.textContent = "Light Mode";
+    } else {
+        darkButton.textContent = "Dark Mode";
+    }
+}
+
 function toggleDarkTheme() {
     document.body.classList.toggle("dark");
     localStorage.setItem('prefersDarkTheme', document.body.classList.contains("dark"));
+    updateDarkModeButtonText();
 }
 
-// Function to toggle retro mode
 function toggleRetroMode() {
     document.body.classList.toggle("retro");
     localStorage.setItem('prefersRetro', document.body.classList.contains("retro"));
 }
 
-// Apply saved preferences on page load
 window.addEventListener("load", () => {
     if (localStorage.getItem('prefersDarkTheme') === 'true' || (localStorage.getItem('prefersDarkTheme') === null && prefersDarkTheme.matches)) {
         document.body.classList.add("dark");
@@ -21,8 +27,8 @@ window.addEventListener("load", () => {
     if (localStorage.getItem('prefersRetro') === 'true') {
         document.body.classList.add('retro');
     }
+    updateDarkModeButtonText();
 });
 
-// Event listeners for theme and retro mode buttons
 document.getElementById("retro").addEventListener("click", toggleRetroMode);
 document.getElementById("dark").addEventListener("click", toggleDarkTheme);

--- a/retro.js
+++ b/retro.js
@@ -1,25 +1,30 @@
+// Check if user prefers dark theme
 const prefersDarkTheme = window.matchMedia("(prefers-color-scheme: dark)");
 
-function updateDarkModeButtonText() {
-    const darkButton = document.getElementById("dark");
-    if (document.body.classList.contains("dark")) {
-        darkButton.textContent = "Light Mode";
-    } else {
-        darkButton.textContent = "Dark Mode";
-    }
-}
-
+// Function to toggle dark theme
 function toggleDarkTheme() {
     document.body.classList.toggle("dark");
     localStorage.setItem('prefersDarkTheme', document.body.classList.contains("dark"));
-    updateDarkModeButtonText();
+    updateModeButtonText();
 }
 
+// Function to toggle retro mode
 function toggleRetroMode() {
     document.body.classList.toggle("retro");
     localStorage.setItem('prefersRetro', document.body.classList.contains("retro"));
 }
 
+// Function to update mode button text
+function updateModeButtonText() {
+    const darkModeButton = document.getElementById('dark');
+    if (document.body.classList.contains("dark")) {
+        darkModeButton.textContent = "Light Mode";
+    } else {
+        darkModeButton.textContent = "Dark Mode";
+    }
+}
+
+// Apply saved preferences on page load
 window.addEventListener("load", () => {
     if (localStorage.getItem('prefersDarkTheme') === 'true' || (localStorage.getItem('prefersDarkTheme') === null && prefersDarkTheme.matches)) {
         document.body.classList.add("dark");
@@ -27,8 +32,5 @@ window.addEventListener("load", () => {
     if (localStorage.getItem('prefersRetro') === 'true') {
         document.body.classList.add('retro');
     }
-    updateDarkModeButtonText();
+    updateModeButtonText(); // Update mode button text on page load
 });
-
-document.getElementById("retro").addEventListener("click", toggleRetroMode);
-document.getElementById("dark").addEventListener("click", toggleDarkTheme);


### PR DESCRIPTION
github pages test for it (So you can see how it works): https://uuphoria2.github.io/sm64coopdx-website/


Test it out here first on the main domain: https://sm64coopdx.com if the color is first dark make it light if its first light then change it to dark. Go on another page and it should reset to dark (Example, the changelog page https://sm64coopdx.com/changelog.html)

https://uuphoria2.github.io/sm64coopdx-website/ if color is first dark again make it light then if its first light then change to dark.
Go on another page like the changelog for example. and it should stay the same setting you wanted which in this case its light Now try reopening and closing it instead of resetting to dark by default on a new tab or closing and opening the website again it should be the same now with this update anytime even if you close and open the website, and even open it in new tabs